### PR TITLE
fix: update workflow references from tf-scans to main

### DIFF
--- a/.github/workflows/ci-terraform.yml
+++ b/.github/workflows/ci-terraform.yml
@@ -27,12 +27,12 @@ on:
 jobs:
   pre-commit:
     name: Pre-Commit
-    uses: "benniemosher-dev/.github/.github/workflows/pre-commit-terraform.yml@tf-scans"
+    uses: "benniemosher-dev/.github/.github/workflows/pre-commit-terraform.yml@main"
     if: ${{ inputs.enable-pre-commit == true }}
 
   security:
     name: Security
-    uses: "benniemosher-dev/.github/.github/workflows/sec-terraform.yml@tf-scans"
+    uses: "benniemosher-dev/.github/.github/workflows/sec-terraform.yml@main"
     if: ${{ inputs.enable-security == true }}
 
   cost:


### PR DESCRIPTION
## Summary
- Change workflow references from `@tf-scans` to `@main`

## Problem
The `ci-terraform.yml` workflow references `@tf-scans` branch which doesn't exist:
```
pre-commit-terraform.yml@tf-scans
sec-terraform.yml@tf-scans
```

This causes all repos using this workflow to fail.

## Solution
Update references to `@main` since that's where the workflows live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)