### PR TITLE
fix: use standard .pre-commit-config.yaml

### DIFF
--- a/.github/workflows/pre-commit-terraform.yml
+++ b/.github/workflows/pre-commit-terraform.yml
@@ -42,4 +42,4 @@ jobs:
 
       - name: Execute pre-commit
         run: |
-          pre-commit run --color=always --show-diff-on-failure --files ${{ steps.file_changes.outputs.files }} --config .pre-commit-config-ci.yaml
+          pre-commit run --color=always --show-diff-on-failure --files ${{ steps.file_changes.outputs.files }} --config .pre-commit-config.yaml


### PR DESCRIPTION
## Summary
- Change pre-commit config from `.pre-commit-config-ci.yaml` to `.pre-commit-config.yaml`

## Problem
The workflow was looking for `.pre-commit-config-ci.yaml` which doesn't exist in repos:
```
InvalidConfigError: .pre-commit-config-ci.yaml is not a file
```

## Solution
Use the standard `.pre-commit-config.yaml` that exists in all repos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)