### PR TITLE
fix: remove missing config_file reference from Checkov step

### DIFF
--- a/.github/workflows/sec-terraform.yml
+++ b/.github/workflows/sec-terraform.yml
@@ -24,7 +24,6 @@ jobs:
         with:
           output_format: cli,sarif
           output_file_path: console,checkov.sarif
-          config_file: .checkov.yaml
 
       - name: Run Terrascan
         id: terrascan


### PR DESCRIPTION
The `config_file: .checkov.yaml` reference has been causing the security check to fail across all repos since January — none of the repos have a `.checkov.yaml` file. Removing it so Checkov runs with defaults.